### PR TITLE
deps: bump GitPython to 3.1.58

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -60,7 +60,7 @@ frozenlist==1.5.0
 fsspec==2024.9.0
 gguf==0.10.0
 gitdb==4.0.12
-GitPython==3.1.44
+GitPython==3.1.58
 gmpy2==2.2.1
 google-api-core==2.24.1
 google-auth==2.38.0


### PR DESCRIPTION
Updates GitPython in requirements.txt to clear the reported advisories.

Evidence:
- requirements.txt pinned GitPython==3.1.44
- osv-scanner reported 22 advisories for GitPython 3.1.44, including GHSA-2f96-g7mh-g2hx (command injection via option prefix abbreviation), GHSA-3f7w-8rr8-f37f (unguarded option forwarding), and GHSA-3rp5-jjmw-4wv2 (config section-name injection)
- updated version: GitPython==3.1.58

Validation:
- osv-scanner no longer reports any GitPython advisory after the update (0 remaining for this package)
- this repo has no test suite; validation is the osv-scanner clearance plus a clean import of git 3.1.58

Scope: requirements.txt only.
